### PR TITLE
Fixed bad link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ On Windows:
 
 ## Next Steps
 
-The Workshop/Tutorial proper is described in the companion [Workshop document](scalding-workshop/Workshop.html).
+The Workshop/Tutorial proper is described in the companion [Workshop document](https://github.com/deanwampler/scalding-workshop/blob/master/Workshop.html).
 
 ## For Further Information
 


### PR DESCRIPTION
The link to the Workshop.html file produced a 404. I made it point at the Github source view of that document on master. I don't know whether there is a good way to force Github to actually serve the file with the correct content type header.
